### PR TITLE
Implement inverted prop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Prop name             | Description   | Type      | Default value
 `initialScrollIndex`  | Index of the item to scroll at startup | int | none
 `initialScrollOffset` | Offset of the scroll position at startup | int | none
 `inverted`            | Reverses the scrolling direction; the first model from the data source is rendered at the bottom | boolean | false
-`itemAnimatorEnabled` | Whether animates items when they are added or removed | bool | true
+`itemAnimatorEnabled` | Whether animates items when they are added or removed | boolean | true
 `ListHeaderComponent` | Component to render as header | component | none
 `ListFooterComponent` | Component to render as footer | component | none
 `ListEmptyComponent`  | Component to render in case of no items | component | none

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A RecyclerView implementation for ReactNative, that overcomes some limitations o
 - **Control the scrolling velocity**: the `velocity` param in the `scrollToIndex` method is exactly for this
 - **Initial scroll index**: specify the scroll position at startup, and there will be no flicker
 - **Low memory usage**: it renders just the visible items plus some extra items around
+- **Supports both scroll direction**: use the `inverted` prop to invert the scroll direction
 
 ## Caveats
 
@@ -93,7 +94,8 @@ Prop name             | Description   | Type      | Default value
 `initialListSize`     | Number of items to render at startup. | int | 10
 `initialScrollIndex`  | Index of the item to scroll at startup | int | none
 `initialScrollOffset` | Offset of the scroll position at startup | int | none
-`itemAnimatorEnabled` | Whether animates items when they are added or removed | boolean | true
+`inverted`            | Reverses the scrolling direction; the first model from the data source is rendered at the bottom | boolean | false
+`itemAnimatorEnabled` | Whether animates items when they are added or removed | bool | true
 `ListHeaderComponent` | Component to render as header | component | none
 `ListFooterComponent` | Component to render as footer | component | none
 `ListEmptyComponent`  | Component to render in case of no items | component | none

--- a/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java
+++ b/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java
@@ -452,6 +452,11 @@ public class RecyclerViewBackedScrollView extends RecyclerView {
         this.getLayoutManager().startSmoothScroll(smoothScroller);
     }
 
+    public void setInverted(boolean inverted) {
+        LinearLayoutManager layoutManager = (LinearLayoutManager) getLayoutManager();
+        layoutManager.setReverseLayout(inverted);
+    }
+
     public void setItemAnimatorEnabled(boolean enabled) {
         if (enabled) {
             DefaultItemAnimator animator = new DefaultItemAnimator();

--- a/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
+++ b/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
@@ -75,6 +75,11 @@ public class RecyclerViewBackedScrollViewManager extends
         parent.getAdapter().notifyDataSetChanged();
     }
 
+    @ReactProp(name = "inverted", defaultBoolean = false)
+    public void setInverted(RecyclerViewBackedScrollView parent, boolean inverted) {
+        parent.setInverted(inverted);
+    }
+
     @ReactProp(name = "itemAnimatorEnabled", defaultBoolean = true)
     public void setItemAnimatorEnabled(RecyclerViewBackedScrollView parent, boolean enabled) {
         parent.setItemAnimatorEnabled(enabled);

--- a/example/App.android.js
+++ b/example/App.android.js
@@ -32,12 +32,13 @@ export default class example extends Component {
     var data = Array(10).fill().map((e,i) => newItem());
 
     this.state = {
-      dataSource: new DataSource(data, (item, index) => item.id)
+      dataSource: new DataSource(data, (item, index) => item.id),
+      inverted: false
     };
   }
 
   render() {
-    const { dataSource } = this.state;
+    const { dataSource, inverted } = this.state;
 
     return (
       <View style={styles.container}>
@@ -49,11 +50,12 @@ export default class example extends Component {
           renderItem={this.renderItem}
           windowSize={20}
           initialScrollIndex={0}
+          inverted={inverted}
           ListHeaderComponent={(
             <View style={{ paddingTop: 15, backgroundColor: '#eee' }} />
           )}
           ListFooterComponent={(
-            <View style={{ paddingTop: 15, backgroundColor: '#eee'}} />
+            <View style={{ paddingTop: 15, backgroundColor: '#aaa'}} />
           )}
           ListEmptyComponent={(
             <View style={{ borderColor: '#e7e7e7', borderWidth: 1, margin: 10, padding: 20, }}>
@@ -111,6 +113,10 @@ export default class example extends Component {
             this._recycler && this._recycler.scrollToIndex({ index, animated: false });
             ToastAndroid.show('Scrolled to item: ' + item.id, ToastAndroid.SHORT);
           }} />
+        <View style={{ width: 5 }} />
+        <Button
+          title={"inv"}
+          onPress={() => { this.setState({inverted: !this.state.inverted}); } } />
       </View>
     );
   }

--- a/src/RecyclerViewList.js
+++ b/src/RecyclerViewList.js
@@ -18,6 +18,9 @@ class RecyclerViewItem extends Component {
   shouldComponentUpdate(nextProps) {
     if (
       (nextProps.itemIndex !== this.props.itemIndex) ||
+      (nextProps.header !== this.props.header) ||
+      (nextProps.footer !== this.props.footer) ||
+      (nextProps.separator !== this.props.separator) ||
       (nextProps.shouldUpdate)
     ) {
       return true;
@@ -188,6 +191,7 @@ class RecyclerView extends React.PureComponent {
       ListFooterComponent,
       ListEmptyComponent,
       ItemSeparatorComponent,
+      inverted,
       ...rest
     } = this.props;
 
@@ -221,6 +225,11 @@ class RecyclerView extends React.PureComponent {
         let item = dataSource.get(i);
         let itemKey = dataSource.getKey(item, i);
         let shouldUpdate = this._needsItemUpdate(itemKey);
+        let isFirst = i == 0;
+        let isLast = i == end;
+        let header = inverted ? (isLast && footerElement) : (isFirst && headerElement);
+        let footer = inverted ? (isFirst && headerElement) : (isLast && footerElement);
+        let separator = inverted ? (!isFirst && separatorElement) : (!isLast && separatorElement);
         body.push(
           <RecyclerViewItem
             key={itemKey}
@@ -229,9 +238,9 @@ class RecyclerView extends React.PureComponent {
             shouldUpdate={shouldUpdate}
             dataSource={dataSource}
             renderItem={renderItem}
-            header={i == 0 && headerElement}
-            separator={i != end && separatorElement}
-            footer={i == end && footerElement} />
+            header={header}
+            separator={separator}
+            footer={footer} />
         );
       }
     } else if (ListEmptyComponent) {
@@ -258,7 +267,8 @@ class RecyclerView extends React.PureComponent {
       <NativeRecyclerView
         {...rest}
         itemCount={stateItemCount}
-        onVisibleItemsChange={this._handleVisibleItemsChange}>
+        onVisibleItemsChange={this._handleVisibleItemsChange}
+        inverted={inverted}>
         {body}
       </NativeRecyclerView>
     );

--- a/src/RecyclerViewList.js
+++ b/src/RecyclerViewList.js
@@ -56,6 +56,7 @@ class RecyclerView extends React.PureComponent {
     initialListSize: PropTypes.number,
     initialScrollIndex: PropTypes.number,
     initialScrollOffset: PropTypes.number,
+    inverted: PropTypes.bool,
     itemAnimatorEnabled: PropTypes.bool,
     ListHeaderComponent: PropTypes.element,
     ListFooterComponent: PropTypes.element,
@@ -68,6 +69,7 @@ class RecyclerView extends React.PureComponent {
     dataSource: new DataSource([], (item, i) => i),
     initialListSize: 10,
     windowSize: 30,
+    inverted: false,
     itemAnimatorEnabled: true,
   }
 


### PR DESCRIPTION
This PR implements the `inverted` prop. Its purpose is simply to revert the scoll direction (ie. the first item will be rendered at the bottom). The name and purpose of the prop are the same as the `inverted` prop for React Native's own `FlatList` component. The implementation simply uses Android's `setReverseLayout()` method.

Hope you find this useful!