### PR TITLE
Fixed compile error when using react-native 0.57.3 (signature of getJSEventName() changed)

### DIFF
--- a/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
+++ b/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
@@ -172,7 +172,7 @@ public class RecyclerViewBackedScrollViewManager extends
     @Nullable
     Map getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.builder()
-                .put(ScrollEventType.SCROLL.getJSEventName(), MapBuilder.of("registrationName", "onScroll"))
+                .put(ScrollEventType.getJSEventName(ScrollEventType.SCROLL), MapBuilder.of("registrationName", "onScroll"))
                 .put(ContentSizeChangeEvent.EVENT_NAME, MapBuilder.of("registrationName", "onContentSizeChange"))
                 .put(VisibleItemsChangeEvent.EVENT_NAME, MapBuilder.of("registrationName", "onVisibleItemsChange"))
                 .build();


### PR DESCRIPTION
When using this module with react-native 0.57.3 the compiler would complain about the signature of getJSEventName(). This has been recently changed in react-native. This PR uses that new implementation. 

Caution this PR breaks with older react-native version and will only be compatible with react-native 0.57.3 and higher.